### PR TITLE
DECLARATION OF INACTIVITY @jimmyhmiller

### DIFF
--- a/players.yaml
+++ b/players.yaml
@@ -1,10 +1,10 @@
 activePlayers:
   - name:  ArchmageInc
     points: 151
-  - name: jimmyhmiller
-    points: 74
   - name: dilbert88 
     points: 67
   - name: rythompson
     points: 18
-inactivePlayers: []
+inactivePlayers: 
+  - name: jimmyhmiller
+    points: 74


### PR DESCRIPTION
Due to lack of participation and communication, I propose this declaration of inactivity on @jimmyhmiller which will remain for one (1) business day. During which time, any comment, vote, proposal, or other activity shall render this declaration discarded. If, however, @jimmyhmiller does not respond within this proposal's lifespan and no other Active Player speaks on his behalf, he will be considered removed from the active player listing and become an Inactive Player.

To reclaim an Active Player status, the subject must submit a request to move from the Inactive Player list onto the Active Player list at which time, the request will be processed, and the subject will again be an Active Player.

In accordance with **110** which states:

>  **110** In order for a player to be active they must be on the active players list. Any player can make a proposal for another player(s) to be declared inactive. A player will be declared inactive if the following criteria have been met: (1) A majority of active players, minus the players who are being declared inactive, must accept the proposal, (2) a 24 hour business day must have passed from the time the proposal was created, (3) none of the players who are being declared inactive have performed any action since the proposal was created. The creator of the proposal may cancel their proposal at any time.

A majority of Active Players, minus those being declared inactive, must approve. Therefore, one other Yay is required.
