### PR TITLE
DECLARATION OF INACTIVITY

### DIFF
--- a/players.yaml
+++ b/players.yaml
@@ -31,9 +31,6 @@ activePlayers:
             farms: 4
             hunger: 0
     -
-        name: rythompson
-        points: 52
-    -
         name: thematrimix
         points: 36
     -
@@ -47,4 +44,7 @@ activePlayers:
                 farming: 14
             farms: 7
             hunger: -137
-inactivePlayers: []
+inactivePlayers:
+    -
+        name: rythompson
+        points: 52


### PR DESCRIPTION
It is hereby declared that @rythompson be considered inactive due to his... lack of activity.

In accordance with rule 110, this will remain for 1 business day and be accepted by >50% of active players less those being declared inactive. Currently, this would be 3 players.

> **110.** In order for a player to be active they must be on the active players list. Any player can make a proposal for another player(s) to be declared inactive. A player will be declared inactive if the following criteria have been met: (1) A majority of active players, minus the players who are being declared inactive, must accept the proposal, (2) a 24 hour business day must have passed from the time the proposal was created, (3) none of the players who are being declared inactive have performed any action since the proposal was created. The creator of the proposal may cancel their proposal at any time.
