### PR TITLE
DECLARATION OF INACTIVITY

### DIFF
--- a/players.yaml
+++ b/players.yaml
@@ -13,6 +13,8 @@ activePlayers:
             hunger: -58
             sawmills: 2
             lumber: 150
+    
+inactivePlayers: 
     -
         name: jimmyhmiller
         points: 334
@@ -54,4 +56,3 @@ activePlayers:
             hunger: -259
             sawmills: 1
             lumber: 0
-inactivePlayers: []


### PR DESCRIPTION
It is hereby declared that @allensb, @jimmyhmiller, @dilbertKocik, @thematrimix, and @rythompson be considered inactive due to their... lack of activity.

In accordance with rule 110, this will remain for 1 business day and be accepted by >50% of active players less those being declared inactive. Currently, this would be 1 player... the one making the declaration... me. I will have a quorum all of you will be inactive, and I'll just sit here and play with myself.

> **110.** In order for a player to be active they must be on the active players list. Any player can make a proposal for another player(s) to be declared inactive. A player will be declared inactive if the following criteria have been met: (1) A majority of active players, minus the players who are being declared inactive, must accept the proposal, (2) a 24 hour business day must have passed from the time the proposal was created, (3) none of the players who are being declared inactive have performed any action since the proposal was created. The creator of the proposal may cancel their proposal at any time.
