### PR TITLE
Convert objects to named exports.

### DIFF
--- a/nomic-bot/src/command-processors/buy-processor.js
+++ b/nomic-bot/src/command-processors/buy-processor.js
@@ -1,122 +1,125 @@
 import _ from 'lodash';
 import stringFormat from 'string-format';
-import github from '../utils/github.js';
-import hungerProcessor from '../schedule-processors/hunger-processor.js';
+import * as github from '../utils/github.js';
+import * as hungerProcessor from '../schedule-processors/hunger-processor.js';
 
-const buyProcessor = {
-    costs: {
-        farm: 10,
-        sawmill: 100
-    },
-    expressions: {
-       farm: /\/buy\s*([0-9]*)\s*farm[s]?\s*$/i,
-       sawmill: /\/buy\s*([0-9]*)\s*sawmill[s]?\s*$/i
-    },
-    messages: {
-        invalid: 'I\'m sorry @{login}, the request entered did not match any of my logic circuits for purchases. Please try something which matches one of the following:\n\n```javascript\n{expressions}```',
-        notActive: '@{login}, you are not an active player and cannot purchase anything.',
-        noVillage: '@{login}, you do not have a village and cannot purchase anything.',
-        nsf: '@{login}, you do not have enough points to purchase {count} {item}(s). You have {balance} points and need {cost} points.',
-        farm: '@{login} purchased {count} farm(s) for {cost} points, which produced enough food to feed {production} people.',
-        sawmill: '@{login} purchased {count} sawmill(s) for {cost} points, which produced {production} lumber.'
+export const costs = {
+    farm: 10,
+    sawmill: 100
+};
 
-    },
-    processBuy: function (commentsUrl, userLogin, requestBody) {
-        const comment = requestBody.comment.body;
-        let result;
+export const expressions = {
+   farm: /\/buy\s*([0-9]*)\s*farm[s]?\s*$/i,
+   sawmill: /\/buy\s*([0-9]*)\s*sawmill[s]?\s*$/i
+};
 
-        _.each(buyProcessor.expressions, function (expression, methodName) {
-            if (expression.test(comment)) {
-                result = github.getPlayerData()
-                    .then(function (playerData) {
-                        const player = _.find(playerData.activePlayers, {name: userLogin});
+export const messages = {
+    invalid: 'I\'m sorry @{login}, the request entered did not match any of my logic circuits for purchases. Please try something which matches one of the following:\n\n```javascript\n{expressions}```',
+    notActive: '@{login}, you are not an active player and cannot purchase anything.',
+    noVillage: '@{login}, you do not have a village and cannot purchase anything.',
+    nsf: '@{login}, you do not have enough points to purchase {count} {item}(s). You have {balance} points and need {cost} points.',
+    farm: '@{login} purchased {count} farm(s) for {cost} points, which produced enough food to feed {production} people.',
+    sawmill: '@{login} purchased {count} sawmill(s) for {cost} points, which produced {production} lumber.'
 
-                        if (!player) {
-                            return github.sendCommentMessage(commentsUrl, stringFormat(buyProcessor.messages.notActive, {login: userLogin}));
-                        }
+};
 
-                        if (!player.village) {
-                            return github.sendCommentMessage(commentsUrl, stringFormat(buyProcessor.messages.noVillage, {login: userLogin}));
-                        }
+export const processBuy = function (commentsUrl, userLogin, requestBody) {
+    const comment = requestBody.comment.body;
+    let result;
 
-                        return buyProcessor[methodName](commentsUrl, requestBody, playerData, player);
-                    });
-            }
-        });
+    _.each(expressions, function (expression, methodName) {
+        if (expression.test(comment)) {
+            result = github.getPlayerData()
+                .then(function (playerData) {
+                    const player = _.find(playerData.activePlayers, {name: userLogin});
 
-        if (!result) {
-            return sendInvalidCommand(commentsUrl, userLogin);
+                    if (!player) {
+                        return github.sendCommentMessage(commentsUrl, stringFormat(messages.notActive, {login: userLogin}));
+                    }
+
+                    if (!player.village) {
+                        return github.sendCommentMessage(commentsUrl, stringFormat(messages.noVillage, {login: userLogin}));
+                    }
+
+                    return methodName(commentsUrl, requestBody, playerData, player);
+                });
         }
+    });
 
-        return result;
-    },
-    sawmill: function (commentsUrl, requestBody, playerData, player) {
-        const purchaseInstruction = buyProcessor.expressions.sawmill.exec(requestBody.comment.body);
-        const count = Number(purchaseInstruction[1]) || 1;
-        const pointCost = count * buyProcessor.costs.sawmill;
-        const production = 0;
-        let message = '';
+    if (!result) {
+        return sendInvalidCommand(commentsUrl, userLogin);
+    }
 
-        if (player.points < pointCost) {
-            return github.sendCommentMessage(commentsUrl, stringFormat(buyProcessor.messages.nsf, {
-                login: player.name,
-                count: count,
-                item: 'sawmill',
-                balance: player.points,
-                cost: pointCost
-            }));
-        }
+    return result;
+};
 
-        player.points -= pointCost;
-        player.village.sawmills = (player.village.sawmills || 0) + count;
-        message = stringFormat(buyProcessor.messages.sawmill, {
+export const sawmill = function (commentsUrl, requestBody, playerData, player) {
+    const purchaseInstruction = expressions.sawmill.exec(requestBody.comment.body);
+    const count = Number(purchaseInstruction[1]) || 1;
+    const pointCost = count * costs.sawmill;
+    const production = 0;
+    let message = '';
+
+    if (player.points < pointCost) {
+        return github.sendCommentMessage(commentsUrl, stringFormat(messages.nsf, {
             login: player.name,
             count: count,
-            cost: pointCost,
-            production: production
-        });
+            item: 'sawmill',
+            balance: player.points,
+            cost: pointCost
+        }));
+    }
 
-        github.sendCommentMessage(commentsUrl, message);
+    player.points -= pointCost;
+    player.village.sawmills = (player.village.sawmills || 0) + count;
+    message = stringFormat(messages.sawmill, {
+        login: player.name,
+        count: count,
+        cost: pointCost,
+        production: production
+    });
 
-        return hungerProcessor.closeHungerIssues(player)
-        .then(function () {
-            return github.updatePlayerFile(playerData, message);
-        });
-    },
-    farm: function (commentsUrl, requestBody, playerData, player) {
-        const purchaseInstruction = buyProcessor.expressions.farm.exec(requestBody.comment.body);
-        const farmCount = Number(purchaseInstruction[1]) || 1;
-        const pointCost = farmCount * buyProcessor.costs.farm;
-        let production = 0;
-        let message = '';
+    github.sendCommentMessage(commentsUrl, message);
 
-        if (player.points < pointCost) {
-            return github.sendCommentMessage(commentsUrl, stringFormat(buyProcessor.messages.nsf, {
-                login: player.name,
-                count: farmCount,
-                item: 'farm',
-                balance: player.points,
-                cost: pointCost
-            }));
-        }
+    return hungerProcessor.closeHungerIssues(player)
+    .then(function () {
+        return github.updatePlayerFile(playerData, message);
+    });
+};
 
-        production = hungerProcessor.processFarmProduction(player, farmCount);
-        player.points -= pointCost;
-        player.village.farms += farmCount;
-        message = stringFormat(buyProcessor.messages.farm, {
+export const farm = function (commentsUrl, requestBody, playerData, player) {
+    const purchaseInstruction = expressions.farm.exec(requestBody.comment.body);
+    const farmCount = Number(purchaseInstruction[1]) || 1;
+    const pointCost = farmCount * costs.farm;
+    let production = 0;
+    let message = '';
+
+    if (player.points < pointCost) {
+        return github.sendCommentMessage(commentsUrl, stringFormat(messages.nsf, {
             login: player.name,
             count: farmCount,
-            cost: pointCost,
-            production: production
-        });
-
-        github.sendCommentMessage(commentsUrl, message);
-
-        return hungerProcessor.closeHungerIssues(player)
-        .then(function () {
-            return github.updatePlayerFile(playerData, message);
-        });
+            item: 'farm',
+            balance: player.points,
+            cost: pointCost
+        }));
     }
+
+    production = hungerProcessor.processFarmProduction(player, farmCount);
+    player.points -= pointCost;
+    player.village.farms += farmCount;
+    message = stringFormat(messages.farm, {
+        login: player.name,
+        count: farmCount,
+        cost: pointCost,
+        production: production
+    });
+
+    github.sendCommentMessage(commentsUrl, message);
+
+    return hungerProcessor.closeHungerIssues(player)
+    .then(function () {
+        return github.updatePlayerFile(playerData, message);
+    });
 };
 
 function sendInvalidCommand(url, userLogin) {
@@ -130,5 +133,3 @@ function sendInvalidCommand(url, userLogin) {
         expressions: expressions
     }));
 }
-
-export default buyProcessor;

--- a/nomic-bot/src/command-processors/close-processor.js
+++ b/nomic-bot/src/command-processors/close-processor.js
@@ -1,39 +1,36 @@
 import _ from 'lodash';
 import stringFormat from 'string-format';
-import github from '../utils/github.js';
-import logger from '../utils/logger.js';
-import voteProcessor from '../command-processors/vote-processor.js';
+import * as github from '../utils/github.js';
+import * as logger from '../utils/logger.js';
+import * as voteProcessor from '../command-processors/vote-processor.js';
 
-const closeProcessor = {
-    messages: {
-        notOwner: '@{login}, you cannot close a proposal which you did not create.',
-        notActive: '@{login}, you cannot close the proposal because you are not an active player.'
-    },
-    processClose: function (commentsUrl, userLogin, requestBody) {
-        const issue = requestBody.issue;
-
-        if (issue.user.login !== userLogin) {
-            return github.sendCommentMessage(commentsUrl, stringFormat(closeProcessor.messages.notOwner, {login: userLogin}));
-        }
-        
-        return github.getPlayerData()
-        .then(function (playerData) {
-            const activePlayers = playerData.activePlayers;
-            const labels = _.map(_.remove(issue.labels, {name: voteProcessor.labelTitles.open}), 'name');
-
-            if (!_.find(activePlayers, {name: userLogin})) {
-                return github.sendCommentMessage(commentsUrl, stringFormat(closeProcessor.messages.notActive, {login: userLogin}));
-            }
-
-            return github.patch({
-                path: issue.url,
-                data: {
-                    state: 'closed',
-                    labels: labels
-                }
-            }).catch(logger.error);
-        });
-    }
+export const messages = {
+    notOwner: '@{login}, you cannot close a proposal which you did not create.',
+    notActive: '@{login}, you cannot close the proposal because you are not an active player.'
 };
 
-export default closeProcessor;
+export const processClose = function (commentsUrl, userLogin, requestBody) {
+    const issue = requestBody.issue;
+
+    if (issue.user.login !== userLogin) {
+        return github.sendCommentMessage(commentsUrl, stringFormat(messages.notOwner, {login: userLogin}));
+    }
+    
+    return github.getPlayerData()
+    .then(function (playerData) {
+        const activePlayers = playerData.activePlayers;
+        const labels = _.map(_.remove(issue.labels, {name: voteProcessor.labelTitles.open}), 'name');
+
+        if (!_.find(activePlayers, {name: userLogin})) {
+            return github.sendCommentMessage(commentsUrl, stringFormat(messages.notActive, {login: userLogin}));
+        }
+
+        return github.patch({
+            path: issue.url,
+            data: {
+                state: 'closed',
+                labels: labels
+            }
+        }).catch(logger.error);
+    });
+};

--- a/nomic-bot/src/command-processors/join-processor.js
+++ b/nomic-bot/src/command-processors/join-processor.js
@@ -1,36 +1,34 @@
 import _ from 'lodash';
 import stringFormat from 'string-format';
-import github from '../utils/github.js';
-import voteProcessor from '../command-processors/vote-processor.js';
-import rollProcessor from '../command-processors/roll-processor.js';
+import * as github from '../utils/github.js';
+import * as  voteProcessor from '../command-processors/vote-processor.js';
+import * as rollProcessor from '../command-processors/roll-processor.js';
 
-const joinProcessor = {
-    messages: {
-        playerCreated: '{login} player has been created!',
-        playerAlreadyCreated: '{login} player has already been created!'
-    },
-    initialPoints: '/roll 1d12 + 12',
-    processJoin: function (commentsUrl, userLogin, requestBody) {
-        return github.getPlayerData()
-        .then(function (playerData) {
-            const activePlayers = playerData.activePlayers;
-            
-            if (_.find(activePlayers, {name: userLogin})) {
-                return github.sendCommentMessage(commentsUrl, stringFormat(joinProcessor.messages.playerAlreadyCreated, {login: userLogin}));
-            }
-
-            const player = {
-                name: userLogin,
-                points: rollProcessor.sum(joinProcessor.initialPoints, {})
-            };
-
-            activePlayers.push(player);
-
-            github.updatePlayerFile(playerData, stringFormat(joinProcessor.messages.playerCreated, {login: userLogin}));
-
-            return;
-        });
-    }
+export const messages = {
+    playerCreated: '{login} player has been created!',
+    playerAlreadyCreated: '{login} player has already been created!'
 };
 
-export default joinProcessor;
+export const initialPoints = '/roll 1d12 + 12';
+
+export const processJoin = function (commentsUrl, userLogin, requestBody) {
+    return github.getPlayerData()
+    .then(function (playerData) {
+        const activePlayers = playerData.activePlayers;
+        
+        if (_.find(activePlayers, {name: userLogin})) {
+            return github.sendCommentMessage(commentsUrl, stringFormat(messages.playerAlreadyCreated, {login: userLogin}));
+        }
+
+        const player = {
+            name: userLogin,
+            points: rollProcessor.sum(initialPoints, {})
+        };
+
+        activePlayers.push(player);
+
+        github.updatePlayerFile(playerData, stringFormat(messages.playerCreated, {login: userLogin}));
+
+        return;
+    });
+};

--- a/nomic-bot/src/command-processors/open-processor.js
+++ b/nomic-bot/src/command-processors/open-processor.js
@@ -1,31 +1,28 @@
 import _ from 'lodash';
 import stringFormat from 'string-format';
-import github from '../utils/github.js';
-import voteProcessor from '../command-processors/vote-processor.js';
+import * as github from '../utils/github.js';
+import * as voteProcessor from '../command-processors/vote-processor.js';
 
-const openProcessor = {
-    messages: {
-        notOwner: '@{login}, you cannot open a proposal which you did not create.',
-        notActive: '@{login}, you cannot open the proposal because you are not an active player.'
-    },
-    processOpen: function (commentsUrl, userLogin, requestBody) {
-        const labelsUrl = requestBody.issue.labels_url;
-
-        if (requestBody.issue.user.login !== userLogin) {
-            return github.sendCommentMessage(commentsUrl, stringFormat(openProcessor.messages.notOwner, {login: userLogin}));
-        }
-        
-        return github.getPlayerData()
-        .then(function (playerData) {
-              const activePlayers = playerData.activePlayers;
-              
-            if (!_.find(activePlayers, {name: userLogin})) {
-                return github.sendCommentMessage(commentsUrl, stringFormat(openProcessor.messages.notActive, {login: userLogin}));
-            }
-
-            return github.addIssueLabels(labelsUrl, [voteProcessor.labelTitles.open]);
-        });
-    }
+export const messages = {
+    notOwner: '@{login}, you cannot open a proposal which you did not create.',
+    notActive: '@{login}, you cannot open the proposal because you are not an active player.'
 };
 
-export default openProcessor;
+export const processOpen = function (commentsUrl, userLogin, requestBody) {
+    const labelsUrl = requestBody.issue.labels_url;
+
+    if (requestBody.issue.user.login !== userLogin) {
+        return github.sendCommentMessage(commentsUrl, stringFormat(messages.notOwner, {login: userLogin}));
+    }
+    
+    return github.getPlayerData()
+    .then(function (playerData) {
+          const activePlayers = playerData.activePlayers;
+          
+        if (!_.find(activePlayers, {name: userLogin})) {
+            return github.sendCommentMessage(commentsUrl, stringFormat(messages.notActive, {login: userLogin}));
+        }
+
+        return github.addIssueLabels(labelsUrl, [voteProcessor.labelTitles.open]);
+    });
+};

--- a/nomic-bot/src/command-processors/resolve-processor.js
+++ b/nomic-bot/src/command-processors/resolve-processor.js
@@ -1,128 +1,132 @@
 import _ from 'lodash';
 import stringFormat from 'string-format';
-import github from '../utils/github.js';
-import logger from '../utils/logger.js';
-import voteProcessor from '../command-processors/vote-processor.js';
+import * as github from '../utils/github.js';
+import * as logger from '../utils/logger.js';
+import * as voteProcessor from '../command-processors/vote-processor.js';
 
-const resolveProcessor = {
-    messages: {
-        notOwner: '@{login}, you cannot resolve a proposal which you did not create.',
-        notActive: '@{login}, you cannot resolve the proposal because you are not an active player.',
-        noQuorum: '@{login}, the proposal does not currently have a quorum and cannot be resolved. To force the proposal to close, use the **/close** command.',
-        tiedVote: '@{login}, the proposal is currently tied and cannot be accepted or rejected. If you wish to close the proposal, use the **/close** command.',
-        mergeProblem: '@{login}, there was a problem performing the PR merge. Good luck on your journey. \n\n The error message was: {message}',
-        pointValue: '@{login} has earned {value} points for the passing of {ordinal} (PR #{issueNumber})' 
-    },
-    hasQuorum: function (issue) {
-        return !!_.find(issue.labels, {name: voteProcessor.labelTitles.quorum});
-    },
-    isPassing: function (issue) {
-        return !!_.find(issue.labels, {name: voteProcessor.labelTitles.passing});
-    },
-    isFailing: function (issue) {
-        return !!_.find(issue.labels, {name: voteProcessor.labelTitles.failing});
-    },
-    isTied: function (issue) {
-        return !!_.find(issue.lables, {name: voteProcessor.labelTitles.tied});
-    },
-    processReject: function (issue) {
-        _.remove(issue.labels, {name: voteProcessor.labelTitles.open});
-        var labels = _.map(issue.labels, 'name');
-        logger.log('  - Closing PR #' + issue.number);
-        return github.patch({
-            path: issue.url,
-            data: {
-                state: 'closed',
-                labels: labels
-            }
-        }).catch(logger.error);
-    },
-    processAccept: function (issue, userLogin) {
-        _.remove(issue.labels, {name: voteProcessor.labelTitles.open});
-        var labels = _.map(issue.labels, 'name');
-        
-        logger.log('  - Removing "' + voteProcessor.labelTitles.open + '" label');
-        
-        return github.patch({
-            path: issue.url,
-            data: {
-                state: 'closed',
-                labels: labels
-            }
-        })
-        .then(function () {
-            logger.log('  - Getting full PR');
-            return github.get({
-                path: issue.pull_request.url
-            }).then(function (pullRequest) {
-                logger.log('  - Attempting to merge PR');
-                return github.put({
-                    path: pullRequest.url + '/merge',
-                    data: {
-                        commit_title: 'Resolving Proposal',
-                        commit_message: 'Resolving Proposal for @' + userLogin,
-                        sha: pullRequest.head.sha
-                    }
-                });
-            });
-        }).catch(logger.error);
-    },
-    processPoints: function (playerData, player, issue) {
-        const ordinal = Number(voteProcessor.expressions.ordinal.exec(issue.title)[1]);
-        const value = ordinal - 291;
-        const message = stringFormat(resolveProcessor.messages.pointValue, {login: player.name, ordinal: ordinal, issueNumber: issue.number, value: value});
-
-        logger.log('  - ' + player.name + ' has earned ' + value + ' points');
-
-        player.points = Number(player.points) + value;
-
-        return github.updatePlayerFile(playerData, message)
-            .then(function () {
-                return github.sendCommentMessage(issue.comments_url, message);
-            });
-    },
-    processResolve: function (commentsUrl, userLogin, requestBody) {
-        const issue = requestBody.issue;
-        
-        if (issue.user.login !== userLogin) {
-            return github.sendCommentMessage(commentsUrl, stringFormat(resolveProcessor.messages.notOwner, {login: userLogin}));
-        }
-        
-        if (!resolveProcessor.hasQuorum(issue)) {
-            return github.sendCommentMessage(commentsUrl, stringFormat(resolveProcessor.messages.noQuorum, {login: userLogin}));
-        }
-        
-        return github.getPlayerData()
-        .then(function (playerData) {
-            logger.info('Processing Resolution');
-
-            const activePlayers = playerData.activePlayers;
-            const player = _.find(activePlayers, {name: userLogin});
-
-            if (!player) {
-                logger.log('  - Not an active player');
-                return github.sendCommentMessage(commentsUrl, stringFormat(resolveProcessor.messages.notActive, {login: userLogin}));
-            }
-
-            if (resolveProcessor.isTied(issue)) {
-                logger.log('  - Issue is tied');
-                return github.sendCommentMessage(commentsUrl, stringFormat(resolveProcessor.messages.tiedVote, {login: userLogin}));
-            }
-
-            if (resolveProcessor.isPassing(issue)) {
-                logger.log('  - Issue is passing');
-                return resolveProcessor.processAccept(issue, userLogin)
-                    .then(_.partial(resolveProcessor.processPoints, playerData, player, issue))
-                    .catch(function (error) {
-                        return github.sendCommentMessage(issue.comments_url, stringFormat(resolveProcessor.messages.mergeProblem, {login: userLogin, message:error.message}));
-                    });
-            }
-
-            logger.log('  - Issue is failing');
-
-            return resolveProcessor.processReject(issue);
-        });
-    }
+export const messages = {
+    notOwner: '@{login}, you cannot resolve a proposal which you did not create.',
+    notActive: '@{login}, you cannot resolve the proposal because you are not an active player.',
+    noQuorum: '@{login}, the proposal does not currently have a quorum and cannot be resolved. To force the proposal to close, use the **/close** command.',
+    tiedVote: '@{login}, the proposal is currently tied and cannot be accepted or rejected. If you wish to close the proposal, use the **/close** command.',
+    mergeProblem: '@{login}, there was a problem performing the PR merge. Good luck on your journey. \n\n The error message was: {message}',
+    pointValue: '@{login} has earned {value} points for the passing of {ordinal} (PR #{issueNumber})' 
 };
 
-export default resolveProcessor;
+export const hasQuorum = function (issue) {
+    return !!_.find(issue.labels, {name: voteProcessor.labelTitles.quorum});
+};
+
+export const isPassing = function (issue) {
+    return !!_.find(issue.labels, {name: voteProcessor.labelTitles.passing});
+};
+
+export const isFailing = function (issue) {
+    return !!_.find(issue.labels, {name: voteProcessor.labelTitles.failing});
+};
+
+export const isTied = function (issue) {
+    return !!_.find(issue.lables, {name: voteProcessor.labelTitles.tied});
+};
+
+export const processReject = function (issue) {
+    _.remove(issue.labels, {name: voteProcessor.labelTitles.open});
+    var labels = _.map(issue.labels, 'name');
+    logger.log('  - Closing PR #' + issue.number);
+    return github.patch({
+        path: issue.url,
+        data: {
+            state: 'closed',
+            labels: labels
+        }
+    }).catch(logger.error);
+};
+
+export const processAccept = function (issue, userLogin) {
+    _.remove(issue.labels, {name: voteProcessor.labelTitles.open});
+    var labels = _.map(issue.labels, 'name');
+    
+    logger.log('  - Removing "' + voteProcessor.labelTitles.open + '" label');
+    
+    return github.patch({
+        path: issue.url,
+        data: {
+            state: 'closed',
+            labels: labels
+        }
+    })
+    .then(function () {
+        logger.log('  - Getting full PR');
+        return github.get({
+            path: issue.pull_request.url
+        }).then(function (pullRequest) {
+            logger.log('  - Attempting to merge PR');
+            return github.put({
+                path: pullRequest.url + '/merge',
+                data: {
+                    commit_title: 'Resolving Proposal',
+                    commit_message: 'Resolving Proposal for @' + userLogin,
+                    sha: pullRequest.head.sha
+                }
+            });
+        });
+    }).catch(logger.error);
+};
+
+export const processPoints = function (playerData, player, issue) {
+    const ordinal = Number(voteProcessor.expressions.ordinal.exec(issue.title)[1]);
+    const value = ordinal - 291;
+    const message = stringFormat(messages.pointValue, {login: player.name, ordinal: ordinal, issueNumber: issue.number, value: value});
+
+    logger.log('  - ' + player.name + ' has earned ' + value + ' points');
+
+    player.points = Number(player.points) + value;
+
+    return github.updatePlayerFile(playerData, message)
+        .then(function () {
+            return github.sendCommentMessage(issue.comments_url, message);
+        });
+};
+
+export const processResolve = function (commentsUrl, userLogin, requestBody) {
+    const issue = requestBody.issue;
+    
+    if (issue.user.login !== userLogin) {
+        return github.sendCommentMessage(commentsUrl, stringFormat(messages.notOwner, {login: userLogin}));
+    }
+    
+    if (!hasQuorum(issue)) {
+        return github.sendCommentMessage(commentsUrl, stringFormat(messages.noQuorum, {login: userLogin}));
+    }
+    
+    return github.getPlayerData()
+    .then(function (playerData) {
+        logger.info('Processing Resolution');
+
+        const activePlayers = playerData.activePlayers;
+        const player = _.find(activePlayers, {name: userLogin});
+
+        if (!player) {
+            logger.log('  - Not an active player');
+            return github.sendCommentMessage(commentsUrl, stringFormat(messages.notActive, {login: userLogin}));
+        }
+
+        if (isTied(issue)) {
+            logger.log('  - Issue is tied');
+            return github.sendCommentMessage(commentsUrl, stringFormat(messages.tiedVote, {login: userLogin}));
+        }
+
+        if (isPassing(issue)) {
+            logger.log('  - Issue is passing');
+            return processAccept(issue, userLogin)
+                .then(_.partial(processPoints, playerData, player, issue))
+                .catch(function (error) {
+                    return github.sendCommentMessage(issue.comments_url, stringFormat(messages.mergeProblem, {login: userLogin, message:error.message}));
+                });
+        }
+
+        logger.log('  - Issue is failing');
+
+        return processReject(issue);
+    });
+};

--- a/nomic-bot/src/command-processors/roll-processor.js
+++ b/nomic-bot/src/command-processors/roll-processor.js
@@ -1,110 +1,112 @@
 import _ from 'lodash';
-import github from '../utils/github.js';
+import * as github from '../utils/github.js';
 
-const rollProcessor = {
-    abusers: {},
-    expressions: {
-        simple: /([0-9]+)\s*[dD]\s*([0-9]+)$/,
-        sum: /([0-9]+)\s*[dD]\s*([0-9]+)\s*\+\s*([0-9]*)$/,
-        subtraction: /([0-9]+)\s*[dD]\s*([0-9]+)\s*\-\s*([0-9]*)$/
-    },
-    processRoll: function (commentsUrl, userLogin, requestBody) {
-        const comment = requestBody.comment.body;
-        const baseExpression = /([0-9]+)\s*[dD]\s*([0-9]+)/;
-        const rollInstruction = baseExpression.exec(comment);
-        const dieCount = rollInstruction ? Number(rollInstruction[1]) : 0;
-        let result;
+export const abusers = {};
 
-        const response = {
-            message: '@' + userLogin + ' requested I roll '
-        };
+export const expressions = {
+    simple: /([0-9]+)\s*[dD]\s*([0-9]+)$/,
+    sum: /([0-9]+)\s*[dD]\s*([0-9]+)\s*\+\s*([0-9]*)$/,
+    subtraction: /([0-9]+)\s*[dD]\s*([0-9]+)\s*\-\s*([0-9]*)$/
+};
+
+export const processRoll = function (commentsUrl, userLogin, requestBody) {
+    const comment = requestBody.comment.body;
+    const baseExpression = /([0-9]+)\s*[dD]\s*([0-9]+)/;
+    const rollInstruction = baseExpression.exec(comment);
+    const dieCount = rollInstruction ? Number(rollInstruction[1]) : 0;
+    let result;
+
+    const response = {
+        message: '@' + userLogin + ' requested I roll '
+    };
 
 
-        ///////////////////////////////////////////////////////////////
-        // INVALID INSTRUCTION
-        ///////////////////////////////////////////////////////////////
-        if (!rollInstruction) {
-            return sendInvalidCommand(commentsUrl, userLogin);
-        }
-
-        ///////////////////////////////////////////////////////////////
-        // ABUSE WARNING
-        ///////////////////////////////////////////////////////////////
-        if (dieCount > 100) {
-            if (abusers[userLogin] >= 3) {
-                return '';
-            }
-            return sendAbuseWarning(commentsUrl, userLogin);
-        }
-
-        _.each(rollProcessor.expressions, function (expression, methodName) {
-            if (expression.test(comment)) {
-                result = rollProcessor[methodName](comment, response);
-            }
-        });
-
-        ///////////////////////////////////////////////////////////////
-        // INVALID INSTRUCTION
-        ///////////////////////////////////////////////////////////////
-        if (!result) {
-            return sendInvalidCommand(commentsUrl, userLogin);
-        }
-
-        response.message += '\n\nBelow are the results:\n\n`';
-
-        if (_.isArray(result)) {
-            _.each(result, function (value) {
-                response.message += '| ' + value + ' ';
-            });
-            response.message += '|';
-        } else {
-            response.message += '| ' + result + ' |';
-        }
-
-        response.message += '`';
-        rollProcessor.abusers[userLogin] = 0;
-        return github.sendCommentMessage(commentsUrl, response.message);
-    },
-
-    roll: function (sides) {
-        return Math.round(Math.random() * (sides - 1) + 1);
-    },
-
-    simple: function (comment, response) {
-        _.defaults(response, {message: ''});
-
-        const rollInstruction = rollProcessor.expressions.simple.exec(comment);
-        const dieCount = Number(rollInstruction[1]);
-        const sides = Number(rollInstruction[2]);
-
-        response.message += dieCount + 'd' + sides + '.';
-
-        return _.times(dieCount, _.partial(rollProcessor.roll, sides));
-    },
-    sum: function (comment, response) {
-        _.defaults(response, {message: ''});
-
-        const rollInstruction = rollProcessor.expressions.sum.exec(comment);
-        const dieCount = Number(rollInstruction[1]);
-        const sides = Number(rollInstruction[2]);
-        const add = Number(rollInstruction[3]);
-
-        response.message += dieCount + 'd' + sides + ' and add ' + add + ' to the total.';
-
-        return _.sum(_.times(dieCount, _.partial(rollProcessor.roll, sides))) + add;
-    },
-    subtraction: function (comment, response) {
-        _.defaults(response, {message: ''});
-
-        const rollInstruction = rollProcessor.expressions.sum.exec(comment);
-        const dieCount = Number(rollInstruction[1]);
-        const sides = Number(rollInstruction[2]);
-        const sub = Number(rollInstruction[3]);
-
-        response.message += dieCount + 'd' + sides + ' and subtract ' + sub + ' from the total.';
-
-        return _.sum(_.times(dieCount, _.partial(rollProcessor.roll, sides))) - sub;
+    ///////////////////////////////////////////////////////////////
+    // INVALID INSTRUCTION
+    ///////////////////////////////////////////////////////////////
+    if (!rollInstruction) {
+        return sendInvalidCommand(commentsUrl, userLogin);
     }
+
+    ///////////////////////////////////////////////////////////////
+    // ABUSE WARNING
+    ///////////////////////////////////////////////////////////////
+    if (dieCount > 100) {
+        if (abusers[userLogin] >= 3) {
+            return '';
+        }
+        return sendAbuseWarning(commentsUrl, userLogin);
+    }
+
+    _.each(expressions, function (expression, methodName) {
+        if (expression.test(comment)) {
+            result = methodName(comment, response);
+        }
+    });
+
+    ///////////////////////////////////////////////////////////////
+    // INVALID INSTRUCTION
+    ///////////////////////////////////////////////////////////////
+    if (!result) {
+        return sendInvalidCommand(commentsUrl, userLogin);
+    }
+
+    response.message += '\n\nBelow are the results:\n\n`';
+
+    if (_.isArray(result)) {
+        _.each(result, function (value) {
+            response.message += '| ' + value + ' ';
+        });
+        response.message += '|';
+    } else {
+        response.message += '| ' + result + ' |';
+    }
+
+    response.message += '`';
+    abusers[userLogin] = 0;
+    return github.sendCommentMessage(commentsUrl, response.message);
+};
+
+export const roll = function (sides) {
+    return Math.round(Math.random() * (sides - 1) + 1);
+};
+
+export const simple = function (comment, response) {
+    _.defaults(response, {message: ''});
+
+    const rollInstruction = expressions.simple.exec(comment);
+    const dieCount = Number(rollInstruction[1]);
+    const sides = Number(rollInstruction[2]);
+
+    response.message += dieCount + 'd' + sides + '.';
+
+    return _.times(dieCount, _.partial(roll, sides));
+};
+
+export const sum = function (comment, response) {
+    _.defaults(response, {message: ''});
+
+    const rollInstruction = expressions.sum.exec(comment);
+    const dieCount = Number(rollInstruction[1]);
+    const sides = Number(rollInstruction[2]);
+    const add = Number(rollInstruction[3]);
+
+    response.message += dieCount + 'd' + sides + ' and add ' + add + ' to the total.';
+
+    return _.sum(_.times(dieCount, _.partial(roll, sides))) + add;
+};
+
+export const subtraction = function (comment, response) {
+    _.defaults(response, {message: ''});
+
+    const rollInstruction = expressions.sum.exec(comment);
+    const dieCount = Number(rollInstruction[1]);
+    const sides = Number(rollInstruction[2]);
+    const sub = Number(rollInstruction[3]);
+
+    response.message += dieCount + 'd' + sides + ' and subtract ' + sub + ' from the total.';
+
+    return _.sum(_.times(dieCount, _.partial(roll, sides))) - sub;
 };
 
 function sendInvalidCommand(url, userLogin) {
@@ -133,5 +135,3 @@ function sendAbuseWarning(url, userLogin) {
     
     return github.sendCommentMessage(url, message);
 }
-
-export default rollProcessor;

--- a/nomic-bot/src/command-processors/vote-processor.js
+++ b/nomic-bot/src/command-processors/vote-processor.js
@@ -1,204 +1,206 @@
 import _ from 'lodash';
 import stringFormat from 'string-format';
-import logger from '../utils/logger.js';
-import github from '../utils/github.js';
-import rollProcessor from '../command-processors/roll-processor.js';
+import * as logger from '../utils/logger.js';
+import * as  github from '../utils/github.js';
+import * as rollProcessor from '../command-processors/roll-processor.js';
 
-const voteProcessor = {
-    incentive: '/roll 2d6+1',
-    labelTitles: {
-        passing: 'Passing',
-        failing: 'Failing',
-        tied: 'Tied',
-        open: 'Open For Voting',
-        quorum: 'Has Quorum'
-    },
-    expressions: {
-        vote: /^yay$|^nay$/i,
-        ordinal: /^([0-9]+)/,
-        positive: /^yay$/i,
-        negative: /^nay$/i,
-        processed: /^@(.*), your vote.* ([0-9]+) points has been added/,
-        pending: /^@(.*), your vote.* ([0-9]+) points will be added/
-    },
-    messages: {
-        notOpen: '@{login}, this proposal is not open for voting. Your vote will not be counted.',
-        notActive: '@{login}, you are not an active player. Your vote will not be counted.',
-        processed: '@{login}, your vote has been processed, a quorum has been reached, and your incentive value of {value} points has been added to your account balance.',
-        pending: '@{login}, your vote has been processed and once a quorum is reached, your incentive value of {value} points will be added to your account balance.',
-        update: 'Adding voting incentive for {playerTags}for proposal {proposal} (PR #{issueNumber}).'
-    },
-    processVote: function (commentsUrl, userLogin, requestBody) {
-        if (!voteProcessor.expressions.ordinal.test(requestBody.issue.title)) {
-            return {message: 'No Ordnial: ' + requestBody.issue.title};
-        }
+export const incentive = '/roll 2d6+1';
 
-        const labelsUrl = requestBody.issue.labels_url;
-        const issueTitle = requestBody.issue.title;
-        const issueOrdinal = voteProcessor.expressions.ordinal.exec(issueTitle)[1];
-        const issueNumber = requestBody.issue.number;
-        const currentLabels = requestBody.issue.labels;
-
-        logger.info('Processing Vote for ' + userLogin + ' on ' + issueOrdinal);
-
-        if (!_.find(currentLabels, {name: voteProcessor.labelTitles.open})) {
-            logger.log('  - Issue is not open for voting');
-            return github.sendCommentMessage(commentsUrl, stringFormat(voteProcessor.messages.notOpen, {login: userLogin}));
-        }
-
-        return github.getAllComments(commentsUrl)
-        .then(function (comments) {
-            return github.getPlayerData()
-                .then(function (playerData) {
-                const activePlayers = playerData.activePlayers;
-                const votes = [];
-                let hasQuorum = false;
-                let voteValue = 0;
-                const labels = [voteProcessor.labelTitles.open];
-                const quorum = Math.ceil(activePlayers.length * 0.5);
-                const processedUsers = [];
-                const pendingUsers = [];
-
-                if (!_.find(activePlayers, {name: userLogin})) {
-                    return github.sendCommentMessage(commentsUrl, stringFormat(voteProcessor.messages.notActive, {login: userLogin}));
-                }
-
-                _.each(comments, function (comment) {
-                    const commentUser = comment.user.login;
-                    const isVote = voteProcessor.expressions.vote.test(comment.body);
-                    const activePlayer = _.find(activePlayers, {name: commentUser});
-                    const hasVoted = _.find(votes, {login: commentUser});
-                    const processed = voteProcessor.expressions.processed.exec(comment.body);
-                    const pending = voteProcessor.expressions.pending.exec(comment.body);
-
-                    var vote = {
-                        login: commentUser,
-                        value: voteProcessor.expressions.positive.test(comment.body) ? 1 : -1
-                    };
-
-                    if (processed && commentUser === github.userLogin) {
-                        
-                        _.remove(pendingUsers, {login: processed[1]});
-                        
-                        processedUsers.push({
-                            login: processed[1],
-                            value: Number(processed[2])
-                        });
-                    }
-
-                    if (pending && commentUser === github.userLogin && !_.find(processed, {login: pending[1]})) {
-                        pendingUsers.push({
-                            login: pending[1],
-                            value: Number(pending[2])
-                        });
-                    }
-
-                    if (hasVoted && isVote) {
-                        _.remove(votes, {login: commentUser});
-                    }
-
-                    if (activePlayer && isVote) {
-                        votes.push(vote);
-                    }
-                });
-
-                _.each(currentLabels, function (labelInfo) {
-                    let found = false;
-                    _.each(voteProcessor.labelTitles, function (labelValue) {
-
-                        if (labelInfo.name !== labelValue) {
-                            found = true;
-                        }
-                    });
-
-                    if (!found) {
-                        labels.push(labelInfo.name);
-                    }
-                });
-
-                logger.log('  === Counting Votes ===');
-                _.each(votes, function (vote) {
-                    logger.log('    - [' + vote.login + ': ' + vote.value + ']');
-                    voteValue += vote.value;
-                });
-                logger.log('  === Finished Counting ===');
-
-                hasQuorum = _.size(votes) >= quorum;
-
-                if (hasQuorum) {
-                    
-                    logger.log('  - ' + issueOrdinal + ' has a qurorum');
-                    
-                    labels.push(voteProcessor.labelTitles.quorum);
-                    if (!_.find(processedUsers, {login: userLogin}) && !_.find(pendingUsers, {login: userLogin})) {
-                        pendingUsers.push(voteProcessor.addPending(commentsUrl, userLogin, hasQuorum));
-                    }
-                    if (pendingUsers.length) {
-                        voteProcessor.processPending(pendingUsers, commentsUrl, issueTitle, issueNumber);
-                    }
-                } else if (!_.find(processedUsers, {login: userLogin}) && !_.find(pendingUsers, {login: userLogin})) {
-                    voteProcessor.addPending(commentsUrl, userLogin, hasQuorum);
-                }
-
-                if (voteValue > 0) {
-                    labels.push(voteProcessor.labelTitles.passing);
-                } else if (voteValue < 0) {
-                    labels.push(voteProcessor.labelTitles.failing);
-                } else {
-                    labels.push(voteProcessor.labelTitles.tied);
-                }
-
-                logger.log('  - Counted ' + _.size(votes));
-                logger.log('  - Needed ' + quorum + ' for quorum');
-                logger.log('  - From a total of ' + activePlayers.length + ' total players');
-                logger.log('  - Current Vote Value is ' + voteValue);
-                logger.log('  - Assigning the following labels:');
-                _.each(labels, function (label) {
-                    logger.log('    - ' + label);
-                });
-
-                return github.setIssueLabels(labelsUrl, labels);
-            });
-        });
-    },
-    addPending: function (commentsUrl, userLogin, hasQuorum) {
-        const incentiveValue = rollProcessor.sum(voteProcessor.incentive, {});
-
-        const pending = {
-            login: userLogin,
-            value: incentiveValue
-        };
-
-        if (!hasQuorum) {
-            github.sendCommentMessage(commentsUrl, stringFormat(voteProcessor.messages.pending, pending));
-        }
-        return pending;
-    },
-    processPending: function (pendingUsers, commentsUrl, issueTitle, issueNumber) {
-        github.getPlayerData()
-        .then(function (playerData) {
-            logger.log('  === Processing Pending Vote Incentives ===');
-            
-            let playerTags = '';
-            _.each(pendingUsers, function (pending) {
-                const player = _.find(playerData.activePlayers, {name: pending.login});
-                
-                if (!player) {
-                    return;
-                }
-                
-                logger.log('    - ' + player.name + ' currently has ' + player.points + ' adding ' + pending.value + ' points');
-                
-                player.points += pending.value;
-                playerTags += '@' + player.name + ' ';
-                github.sendCommentMessage(commentsUrl, stringFormat(voteProcessor.messages.processed, pending));
-            });
-            github.updatePlayerFile(playerData, stringFormat(voteProcessor.messages.update, {playerTags: playerTags, proposal: issueTitle, issueNumber: issueNumber}))
-            .then(function () {
-                logger.log('  === Finished Pending Vote Incentives ===');
-            });
-        });
-    }
+export const labelTitles = {
+    passing: 'Passing',
+    failing: 'Failing',
+    tied: 'Tied',
+    open: 'Open For Voting',
+    quorum: 'Has Quorum'
 };
 
-export default voteProcessor;
+export const expressions = {
+    vote: /^yay$|^nay$/i,
+    ordinal: /^([0-9]+)/,
+    positive: /^yay$/i,
+    negative: /^nay$/i,
+    processed: /^@(.*), your vote.* ([0-9]+) points has been added/,
+    pending: /^@(.*), your vote.* ([0-9]+) points will be added/
+};
+
+export const messages = {
+    notOpen: '@{login}, this proposal is not open for voting. Your vote will not be counted.',
+    notActive: '@{login}, you are not an active player. Your vote will not be counted.',
+    processed: '@{login}, your vote has been processed, a quorum has been reached, and your incentive value of {value} points has been added to your account balance.',
+    pending: '@{login}, your vote has been processed and once a quorum is reached, your incentive value of {value} points will be added to your account balance.',
+    update: 'Adding voting incentive for {playerTags}for proposal {proposal} (PR #{issueNumber}).'
+};
+
+export const processVote = function (commentsUrl, userLogin, requestBody) {
+    if (!expressions.ordinal.test(requestBody.issue.title)) {
+        return {message: 'No Ordnial: ' + requestBody.issue.title};
+    }
+
+    const labelsUrl = requestBody.issue.labels_url;
+    const issueTitle = requestBody.issue.title;
+    const issueOrdinal = expressions.ordinal.exec(issueTitle)[1];
+    const issueNumber = requestBody.issue.number;
+    const currentLabels = requestBody.issue.labels;
+
+    logger.info('Processing Vote for ' + userLogin + ' on ' + issueOrdinal);
+
+    if (!_.find(currentLabels, {name: labelTitles.open})) {
+        logger.log('  - Issue is not open for voting');
+        return github.sendCommentMessage(commentsUrl, stringFormat(messages.notOpen, {login: userLogin}));
+    }
+
+    return github.getAllComments(commentsUrl)
+    .then(function (comments) {
+        return github.getPlayerData()
+            .then(function (playerData) {
+            const activePlayers = playerData.activePlayers;
+            const votes = [];
+            let hasQuorum = false;
+            let voteValue = 0;
+            const labels = [labelTitles.open];
+            const quorum = Math.ceil(activePlayers.length * 0.5);
+            const processedUsers = [];
+            const pendingUsers = [];
+
+            if (!_.find(activePlayers, {name: userLogin})) {
+                return github.sendCommentMessage(commentsUrl, stringFormat(messages.notActive, {login: userLogin}));
+            }
+
+            _.each(comments, function (comment) {
+                const commentUser = comment.user.login;
+                const isVote = expressions.vote.test(comment.body);
+                const activePlayer = _.find(activePlayers, {name: commentUser});
+                const hasVoted = _.find(votes, {login: commentUser});
+                const processed = expressions.processed.exec(comment.body);
+                const pending = expressions.pending.exec(comment.body);
+
+                var vote = {
+                    login: commentUser,
+                    value: expressions.positive.test(comment.body) ? 1 : -1
+                };
+
+                if (processed && commentUser === github.userLogin) {
+                    
+                    _.remove(pendingUsers, {login: processed[1]});
+                    
+                    processedUsers.push({
+                        login: processed[1],
+                        value: Number(processed[2])
+                    });
+                }
+
+                if (pending && commentUser === github.userLogin && !_.find(processed, {login: pending[1]})) {
+                    pendingUsers.push({
+                        login: pending[1],
+                        value: Number(pending[2])
+                    });
+                }
+
+                if (hasVoted && isVote) {
+                    _.remove(votes, {login: commentUser});
+                }
+
+                if (activePlayer && isVote) {
+                    votes.push(vote);
+                }
+            });
+
+            _.each(currentLabels, function (labelInfo) {
+                let found = false;
+                _.each(labelTitles, function (labelValue) {
+
+                    if (labelInfo.name !== labelValue) {
+                        found = true;
+                    }
+                });
+
+                if (!found) {
+                    labels.push(labelInfo.name);
+                }
+            });
+
+            logger.log('  === Counting Votes ===');
+            _.each(votes, function (vote) {
+                logger.log('    - [' + vote.login + ': ' + vote.value + ']');
+                voteValue += vote.value;
+            });
+            logger.log('  === Finished Counting ===');
+
+            hasQuorum = _.size(votes) >= quorum;
+
+            if (hasQuorum) {
+                
+                logger.log('  - ' + issueOrdinal + ' has a qurorum');
+                
+                labels.push(labelTitles.quorum);
+                if (!_.find(processedUsers, {login: userLogin}) && !_.find(pendingUsers, {login: userLogin})) {
+                    pendingUsers.push(addPending(commentsUrl, userLogin, hasQuorum));
+                }
+                if (pendingUsers.length) {
+                    processPending(pendingUsers, commentsUrl, issueTitle, issueNumber);
+                }
+            } else if (!_.find(processedUsers, {login: userLogin}) && !_.find(pendingUsers, {login: userLogin})) {
+                addPending(commentsUrl, userLogin, hasQuorum);
+            }
+
+            if (voteValue > 0) {
+                labels.push(labelTitles.passing);
+            } else if (voteValue < 0) {
+                labels.push(labelTitles.failing);
+            } else {
+                labels.push(labelTitles.tied);
+            }
+
+            logger.log('  - Counted ' + _.size(votes));
+            logger.log('  - Needed ' + quorum + ' for quorum');
+            logger.log('  - From a total of ' + activePlayers.length + ' total players');
+            logger.log('  - Current Vote Value is ' + voteValue);
+            logger.log('  - Assigning the following labels:');
+            _.each(labels, function (label) {
+                logger.log('    - ' + label);
+            });
+
+            return github.setIssueLabels(labelsUrl, labels);
+        });
+    });
+};
+
+export const addPending = function (commentsUrl, userLogin, hasQuorum) {
+    const incentiveValue = rollProcessor.sum(incentive, {});
+
+    const pending = {
+        login: userLogin,
+        value: incentiveValue
+    };
+
+    if (!hasQuorum) {
+        github.sendCommentMessage(commentsUrl, stringFormat(messages.pending, pending));
+    }
+    return pending;
+};
+
+export const processPending = function (pendingUsers, commentsUrl, issueTitle, issueNumber) {
+    github.getPlayerData()
+    .then(function (playerData) {
+        logger.log('  === Processing Pending Vote Incentives ===');
+        
+        let playerTags = '';
+        _.each(pendingUsers, function (pending) {
+            const player = _.find(playerData.activePlayers, {name: pending.login});
+            
+            if (!player) {
+                return;
+            }
+            
+            logger.log('    - ' + player.name + ' currently has ' + player.points + ' adding ' + pending.value + ' points');
+            
+            player.points += pending.value;
+            playerTags += '@' + player.name + ' ';
+            github.sendCommentMessage(commentsUrl, stringFormat(messages.processed, pending));
+        });
+        github.updatePlayerFile(playerData, stringFormat(messages.update, {playerTags: playerTags, proposal: issueTitle, issueNumber: issueNumber}))
+        .then(function () {
+            logger.log('  === Finished Pending Vote Incentives ===');
+        });
+    });
+};

--- a/nomic-bot/src/endpoint-processors/comment-processor.js
+++ b/nomic-bot/src/endpoint-processors/comment-processor.js
@@ -2,14 +2,14 @@ import Q from 'q';
 import _ from 'lodash';
 import multi from 'multiple-methods';
 
-import logger from '../utils/logger.js';
-import rollProcessor from '../command-processors/roll-processor.js';
-import voteProcessor from '../command-processors/vote-processor.js';
-import openProcessor from '../command-processors/open-processor.js';
-import closeProcessor from '../command-processors/close-processor.js';
-import buyProcessor from '../command-processors/buy-processor.js';
-import resolveProcessor from '../command-processors/resolve-processor.js';
-import joinProcessor from '../command-processors/join-processor.js';
+import * as logger from '../utils/logger.js';
+import * as rollProcessor from '../command-processors/roll-processor.js';
+import * as voteProcessor from '../command-processors/vote-processor.js';
+import * as openProcessor from '../command-processors/open-processor.js';
+import * as closeProcessor from '../command-processors/close-processor.js';
+import * as buyProcessor from '../command-processors/buy-processor.js';
+import * as resolveProcessor from '../command-processors/resolve-processor.js';
+import * as joinProcessor from '../command-processors/join-processor.js';
 import * as universe from '../universe';
 
 

--- a/nomic-bot/src/index.js
+++ b/nomic-bot/src/index.js
@@ -4,11 +4,11 @@ import { bang } from './universe/big-bang';
 const testing = process.env.TESTING || false;
 import serverConfig from './config/server-config.js';
 import ApiServer from './utils/api-server.js';
-import logger from './utils/logger.js';
+import * as logger from './utils/logger.js';
 import * as commentProcessor from './endpoint-processors/comment-processor.js';
-import hungerProcessor from './schedule-processors/hunger-processor.js';
-import populationGrowthProcessor from './schedule-processors/population-growth-processor.js';
-import sawmillProcessor from './schedule-processors/sawmill-processor.js';
+import * as hungerProcessor from './schedule-processors/hunger-processor.js';
+import * as populationGrowthProcessor from './schedule-processors/population-growth-processor.js';
+import * as sawmillProcessor from './schedule-processors/sawmill-processor.js';
 const apiServer = new ApiServer(serverConfig);
 
 if (testing) {

--- a/nomic-bot/src/schedule-processors/hunger-processor.js
+++ b/nomic-bot/src/schedule-processors/hunger-processor.js
@@ -4,234 +4,243 @@ import moment from 'moment-timezone';
 import _ from 'lodash';
 import stringFormat from 'string-format';
 import config from '../config/server-config.js';
-import logger from '../utils/logger.js';
-import github from '../utils/github.js';
-import rollProcessor from '../command-processors/roll-processor.js';
+import * as logger from '../utils/logger.js';
+import * as github from '../utils/github.js';
+import * as rollProcessor from '../command-processors/roll-processor.js';
 
-const hungerProcessor = {
-    job: null,
-    jobSchedule: '0 0 15 * * 3',
-    farmProduction: '/roll 1d12+12',
-    farmersRequired: 2,
-    messages: {
-        famineTitle: '@{login} feed your population!',
-        famine: '@{login}\'s village of {villageName} has famine in their population! \n\n There are {farmCount} active farms, which produced enough to feed {production} people this week. An additional {hungerCount} people need food.',
-        starvation: '@{login}\'s village, {villageName} had {deathCount} people starve to death.',
-        wipeOut: '@{login}\'s village has all starved to death. Their village has been removed, and their points have been reduced to 0.',
-        resolved: '@{login} has resolved their villages hungry population.'
-    },
-    labelTitles: {
-        hunger: 'Hunger'
-    },
-    scheduleJob: function () {
-        if (hungerProcessor.job) {
-            hungerProcessor.job.cancel();
+export let job = null;
+export const jobSchedule = '0 0 15 * * 3';
+export const farmProduction = '/roll 1d12+12';
+export const farmersRequired = 2;
+
+export const messages = {
+    famineTitle: '@{login} feed your population!',
+    famine: '@{login}\'s village of {villageName} has famine in their population! \n\n There are {farmCount} active farms, which produced enough to feed {production} people this week. An additional {hungerCount} people need food.',
+    starvation: '@{login}\'s village, {villageName} had {deathCount} people starve to death.',
+    wipeOut: '@{login}\'s village has all starved to death. Their village has been removed, and their points have been reduced to 0.',
+    resolved: '@{login} has resolved their villages hungry population.'
+};
+
+export const labelTitles = {
+    hunger: 'Hunger'
+};
+
+export const scheduleJob = function () {
+    if (job) {
+        job.cancel();
+    }
+    job = schedule.scheduleJob(jobSchedule, processHunger);
+    logger.info('Creating Hunger Job. Next Run: ' + getNextRun());
+};
+
+export const getNextRun = function () {
+    if (job) {
+        return moment(job.pendingInvocations()[0].fireDate).tz(config.timezone).format('M/D/YY HH:mm z');
+    }
+    return 'NONE';
+};
+
+export const createHungerIssue = function (player, production) {
+    const message = stringFormat(messages.famine, {
+        login: player.name,
+        villageName: player.village.name,
+        farmCount: getActiveFarms(player),
+        production: production,
+        hungerCount: player.village.hunger
+    });
+    
+    logger.log('  - ' + message);
+    
+    return github.post({
+        endpoint: 'issues',
+        data: {
+            title: stringFormat(messages.famineTitle, {login: player.name}),
+            body: message,
+            assignee: player.name,
+            labels: [
+                labelTitles.hunger
+            ]
         }
-        hungerProcessor.job = schedule.scheduleJob(hungerProcessor.jobSchedule, hungerProcessor.processHunger);
-        logger.info('Creating Hunger Job. Next Run: ' + hungerProcessor.getNextRun());
-    },
-    getNextRun: function () {
-        if (hungerProcessor.job) {
-            return moment(hungerProcessor.job.pendingInvocations()[0].fireDate).tz(config.timezone).format('M/D/YY HH:mm z');
-        }
-        return 'NONE';
-    },
-    createHungerIssue: function (player, production) {
-        const message = stringFormat(hungerProcessor.messages.famine, {
-            login: player.name,
-            villageName: player.village.name,
-            farmCount: hungerProcessor.getActiveFarms(player),
-            production: production,
-            hungerCount: player.village.hunger
-        });
-        
-        logger.log('  - ' + message);
-        
-        return github.post({
+    }).catch(logger.error);
+};
+
+export const closeHungerIssues = function (player) {
+    if (_.get(player, 'village.hunger') <= 0) {
+        return github.get({
             endpoint: 'issues',
-            data: {
-                title: stringFormat(hungerProcessor.messages.famineTitle, {login: player.name}),
-                body: message,
-                assignee: player.name,
-                labels: [
-                    hungerProcessor.labelTitles.hunger
-                ]
+            query: {
+                labels: labelTitles.hunger,
+                per_page: 100
             }
-        }).catch(logger.error);
-    },
-    closeHungerIssues: function (player) {
-        if (_.get(player, 'village.hunger') <= 0) {
-            return github.get({
-                endpoint: 'issues',
-                query: {
-                    labels: hungerProcessor.labelTitles.hunger,
-                    per_page: 100
-                }
-            }).then(function (issues) {
-                if (!issues || !issues.length) {
-                    return;
-                }
-                return Q.all(_.map(issues, function (issue) {
-                    if (issue.assignee.login === player.name) {
-                        return github.sendCommentMessage(issue.comments_url, stringFormat(hungerProcessor.messages.resolved, {login: player.name}))
-                        .then(function () {
-                            return github.patch({
-                                path: issue.url,
-                                data: {
-                                    state: 'closed'
-                                }
-                            });
-                        });
-                    }
-                }));
-            })
-            .catch(logger.error);
-        }
-        return Q.when();
-    },
-    reducePopulation: function (player, amount) {
-        if (!_.get(player, 'village.population') || !_.isObject(player.village.population)) {
-            return 0;
-        }
-        if (amount <= player.village.population.general) {
-            player.village.population.general -= amount;
-            return 0;
-        }
-
-        amount += player.village.population.general;
-        player.village.population.general = 0;
-
-        const keys = _.keys(player.village.population);
-
-        _.each(keys, function (key, index) {
-            if (player.village.population[key] <= 0) {
-                keys.splice(index, 1);
-            }
-        });
-
-        _.times(amount, function () {
-            const index = _.random(0, keys.length - 1);
-            const key = keys[index];
-
-            if (!keys.length) {
+        }).then(function (issues) {
+            if (!issues || !issues.length) {
                 return;
             }
-
-            player.village.population[key]--;
-            amount--;
-            if (player.village.population[key] <= 0) {
-                keys.splice(index, 1);
-            }
-        });
-
-        return amount;
-
-    },
-    processStarvation: function (playerData, player) {
-        const populationCount = hungerProcessor.getTotalPopulation(player);
-        const deathCount = Math.min(populationCount, player.village.hunger);
-
-        const message = stringFormat(hungerProcessor.messages.starvation, {
-            login: player.name,
-            villageName: player.village.name,
-            deathCount: deathCount
-        });
-
-        logger.log('  - ' + message);
-
-        hungerProcessor.reducePopulation(player, deathCount);
-
-        player.village.hunger = 0;
-
-        github.updatePlayerFile(playerData, message);
-
-        return deathCount;
-    },
-    getActiveFarms: function (player, farmCount) {
-        const farms = farmCount || _.get(player, 'village.farms', 0);
-        const farmers = _.get(player, 'village.population.farming', 0);
-
-        return Math.floor(Math.max(0, farms - Math.max(0, farms * hungerProcessor.farmersRequired - farmers) / hungerProcessor.farmersRequired));
-    },
-    processFarmProduction: function (player, farms) {
-        const activeFarms = hungerProcessor.getActiveFarms(player, farms);
-        const production = _.sum(_.times(activeFarms, _.partial(rollProcessor.sum, hungerProcessor.farmProduction, {})));
-        const currentHunger = _.get(player, 'village.hunger', 0);
-
-        logger.log('  - Processing Farm Production for ' + player.name + ': ' + activeFarms + ' - ' + production);
-
-        if (!player || !player.village) {
-            return 0;
-        }
-
-        player.village.hunger = currentHunger - production;
-
-        return production;
-    },
-    processPlayerHunger: function (playerData, player) {
-        if (!player.village) {
-            logger.log('  - ' + player.name + ': NO VILLAGE');
-            return;
-        }
-
-        if (!player.village.population) {
-            logger.log('  - ' + player.name + ': NO POPULATION');
-            return;
-        }
-
-        if (_.isNumber(player.village.population)) {
-            player.village.population = {
-                general: player.village.population
-            };
-        }
-
-        if (player.village.hunger > 0) {
-            hungerProcessor.processStarvation(playerData, player);
-        }
-
-        if (hungerProcessor.getTotalPopulation(player) === 0) {
-            delete player.village;
-            player.points = 0;
-            github.updatePlayerFile(playerData, stringFormat(hungerProcessor.messages.wipeOut, {
-                login: player.name
-            }));
-            return;
-        }
-
-        const production = hungerProcessor.processFarmProduction(player);
-        const populationCount = hungerProcessor.getTotalPopulation(player);
-
-        player.village.hunger += populationCount;
-
-        logger.log('  - ' + player.name + ': population - ' + populationCount + ' | hunger: ' + player.village.hunger);
-
-        if (player.village.hunger > 0 ) {
-            hungerProcessor.createHungerIssue(player, production);
-        }
-    },
-    processHunger: function () {
-        logger.info('Performing Hunger Process...');
-        
-        return github.getPlayerData()
-            .then(function (playerData){
-                if (!playerData.activePlayers) {
-                    logger.warn('No active players found!');
-                    return;
-                }
-
-                logger.log(' :: ' + playerData.activePlayers.length + ' active players :: ');
-
-                _.each(playerData.activePlayers, _.partial(hungerProcessor.processPlayerHunger, playerData));
-
-                return github.updatePlayerFile(playerData, 'Feeding the population.')
-                    .finally(function () {
-                        logger.info('Finished Hunger Process. Next Hunger Job Scheduled to run at ' + hungerProcessor.getNextRun());
+            return Q.all(_.map(issues, function (issue) {
+                if (issue.assignee.login === player.name) {
+                    return github.sendCommentMessage(issue.comments_url, stringFormat(messages.resolved, {login: player.name}))
+                    .then(function () {
+                        return github.patch({
+                            path: issue.url,
+                            data: {
+                                state: 'closed'
+                            }
+                        });
                     });
-            });
-    },
-    getTotalPopulation: function (player) {
-        return _.sum(_.values(_.get(player, 'village.population')));
+                }
+            }));
+        })
+        .catch(logger.error);
+    }
+    return Q.when();
+};
+
+export const reducePopulation = function (player, amount) {
+    if (!_.get(player, 'village.population') || !_.isObject(player.village.population)) {
+        return 0;
+    }
+    if (amount <= player.village.population.general) {
+        player.village.population.general -= amount;
+        return 0;
+    }
+
+    amount += player.village.population.general;
+    player.village.population.general = 0;
+
+    const keys = _.keys(player.village.population);
+
+    _.each(keys, function (key, index) {
+        if (player.village.population[key] <= 0) {
+            keys.splice(index, 1);
+        }
+    });
+
+    _.times(amount, function () {
+        const index = _.random(0, keys.length - 1);
+        const key = keys[index];
+
+        if (!keys.length) {
+            return;
+        }
+
+        player.village.population[key]--;
+        amount--;
+        if (player.village.population[key] <= 0) {
+            keys.splice(index, 1);
+        }
+    });
+
+    return amount;
+
+};
+
+export const processStarvation = function (playerData, player) {
+    const populationCount = getTotalPopulation(player);
+    const deathCount = Math.min(populationCount, player.village.hunger);
+
+    const message = stringFormat(messages.starvation, {
+        login: player.name,
+        villageName: player.village.name,
+        deathCount: deathCount
+    });
+
+    logger.log('  - ' + message);
+
+    reducePopulation(player, deathCount);
+
+    player.village.hunger = 0;
+
+    github.updatePlayerFile(playerData, message);
+
+    return deathCount;
+};
+
+export const getActiveFarms = function (player, farmCount) {
+    const farms = farmCount || _.get(player, 'village.farms', 0);
+    const farmers = _.get(player, 'village.population.farming', 0);
+
+    return Math.floor(Math.max(0, farms - Math.max(0, farms * farmersRequired - farmers) / farmersRequired));
+};
+
+export const processFarmProduction = function (player, farms) {
+    const activeFarms = getActiveFarms(player, farms);
+    const production = _.sum(_.times(activeFarms, _.partial(rollProcessor.sum, farmProduction, {})));
+    const currentHunger = _.get(player, 'village.hunger', 0);
+
+    logger.log('  - Processing Farm Production for ' + player.name + ': ' + activeFarms + ' - ' + production);
+
+    if (!player || !player.village) {
+        return 0;
+    }
+
+    player.village.hunger = currentHunger - production;
+
+    return production;
+};
+
+export const processPlayerHunger = function (playerData, player) {
+    if (!player.village) {
+        logger.log('  - ' + player.name + ': NO VILLAGE');
+        return;
+    }
+
+    if (!player.village.population) {
+        logger.log('  - ' + player.name + ': NO POPULATION');
+        return;
+    }
+
+    if (_.isNumber(player.village.population)) {
+        player.village.population = {
+            general: player.village.population
+        };
+    }
+
+    if (player.village.hunger > 0) {
+        processStarvation(playerData, player);
+    }
+
+    if (getTotalPopulation(player) === 0) {
+        delete player.village;
+        player.points = 0;
+        github.updatePlayerFile(playerData, stringFormat(messages.wipeOut, {
+            login: player.name
+        }));
+        return;
+    }
+
+    const production = processFarmProduction(player);
+    const populationCount = getTotalPopulation(player);
+
+    player.village.hunger += populationCount;
+
+    logger.log('  - ' + player.name + ': population - ' + populationCount + ' | hunger: ' + player.village.hunger);
+
+    if (player.village.hunger > 0 ) {
+        createHungerIssue(player, production);
     }
 };
 
-export default hungerProcessor;
+export const processHunger = function () {
+    logger.info('Performing Hunger Process...');
+    
+    return github.getPlayerData()
+        .then(function (playerData){
+            if (!playerData.activePlayers) {
+                logger.warn('No active players found!');
+                return;
+            }
+
+            logger.log(' :: ' + playerData.activePlayers.length + ' active players :: ');
+
+            _.each(playerData.activePlayers, _.partial(processPlayerHunger, playerData));
+
+            return github.updatePlayerFile(playerData, 'Feeding the population.')
+                .finally(function () {
+                    logger.info('Finished Hunger Process. Next Hunger Job Scheduled to run at ' + getNextRun());
+                });
+        });
+};
+
+export const getTotalPopulation = function (player) {
+    return _.sum(_.values(_.get(player, 'village.population')));
+};

--- a/nomic-bot/src/schedule-processors/population-growth-processor.js
+++ b/nomic-bot/src/schedule-processors/population-growth-processor.js
@@ -2,76 +2,78 @@ import schedule from 'node-schedule';
 import moment from 'moment-timezone';
 import _ from 'lodash';
 import config from '../config/server-config.js';
-import logger from '../utils/logger.js';
-import github from '../utils/github.js';
+import * as logger from '../utils/logger.js';
+import * as github from '../utils/github.js';
 
-const populationGrowthProcessor = {
-    job: null,
-    jobSchedule: '0 0 15 1 * *',
-    growthFunction: function (n, h) {
-        const v = 1/(Math.pow(h+n,2)+1);
-        return Math.floor(n * Math.pow(Math.E, 0.011 + v));
-    },
-    scheduleJob: function () {
-        if (populationGrowthProcessor.job) {
-            populationGrowthProcessor.job.cancel();
-        }
-        populationGrowthProcessor.job = schedule.scheduleJob(populationGrowthProcessor.jobSchedule, populationGrowthProcessor.processGrowth);
-        logger.info('Creating Population Growth Job. Next Run: ' + populationGrowthProcessor.getNextRun());
-    },
-    getNextRun: function () {
-        if (populationGrowthProcessor.job) {
-            return moment(populationGrowthProcessor.job.pendingInvocations()[0].fireDate).tz(config.timezone).format('M/D/YY HH:mm z');
-        }
-        return 'NONE';
-    },
-    processGrowth: function () {
-        logger.info('Performing Population Growth Process...');
-        return github.getPlayerData()
-            .then(function (playerData){
-                if (!playerData.activePlayers) {
-                    logger.warn('No active players found!');
-                    return;
-                }
+export let job = null;
+export const jobSchedule = '0 0 15 1 * *';
 
-                logger.log(' :: ' + playerData.activePlayers.length + ' active players :: ');
-
-                _.each(playerData.activePlayers, populationGrowthProcessor.processPlayerGrowth);
-
-                return github.updatePlayerFile(playerData, 'Growing the population.')
-                    .finally(function () {
-                        logger.info('Finished Population Growth Process. Next Population Growth Job Scheduled to run at ' + populationGrowthProcessor.getNextRun());
-                    });
-            });
-    },
-    processPlayerGrowth: function (player) {
-        if (!player.village) {
-            logger.log('  - ' + player.name + ': NO VILLAGE');
-            return;
-        }
-
-        if (!player.village.population) {
-            logger.log('  - ' + player.name + ': NO POPULATION');
-            return;
-        }
-
-        if (_.isNumber(player.village.population)) {
-            player.village.population = {
-                general: player.village.population
-            };
-        }
-
-        const populationCount = populationGrowthProcessor.getTotalPopulation(player);
-        const newPopulationCount = populationGrowthProcessor.growthFunction(populationCount, player.village.hunger);
-        const populationGrowth = newPopulationCount - populationCount;
-
-        player.village.population.general += populationGrowth;
-
-        logger.log('  - ' + player.name + ': population - ' + newPopulationCount + ' | hunger: ' + player.village.hunger);
-    },
-    getTotalPopulation: function (player) {
-        return _.sum(_.values(_.get(player, 'village.population')));
-    }
+export const growthFunction = function (n, h) {
+    const v = 1/(Math.pow(h+n,2)+1);
+    return Math.floor(n * Math.pow(Math.E, 0.011 + v));
 };
 
-export default populationGrowthProcessor;
+export const scheduleJob = function () {
+    if (job) {
+        job.cancel();
+    }
+    job = schedule.scheduleJob(jobSchedule, processGrowth);
+    logger.info('Creating Population Growth Job. Next Run: ' + getNextRun());
+};
+
+export const getNextRun = function () {
+    if (job) {
+        return moment(job.pendingInvocations()[0].fireDate).tz(config.timezone).format('M/D/YY HH:mm z');
+    }
+    return 'NONE';
+};
+
+export const processGrowth = function () {
+    logger.info('Performing Population Growth Process...');
+    return github.getPlayerData()
+        .then(function (playerData){
+            if (!playerData.activePlayers) {
+                logger.warn('No active players found!');
+                return;
+            }
+
+            logger.log(' :: ' + playerData.activePlayers.length + ' active players :: ');
+
+            _.each(playerData.activePlayers, processPlayerGrowth);
+
+            return github.updatePlayerFile(playerData, 'Growing the population.')
+                .finally(function () {
+                    logger.info('Finished Population Growth Process. Next Population Growth Job Scheduled to run at ' + getNextRun());
+                });
+        });
+};
+
+export const processPlayerGrowth = function (player) {
+    if (!player.village) {
+        logger.log('  - ' + player.name + ': NO VILLAGE');
+        return;
+    }
+
+    if (!player.village.population) {
+        logger.log('  - ' + player.name + ': NO POPULATION');
+        return;
+    }
+
+    if (_.isNumber(player.village.population)) {
+        player.village.population = {
+            general: player.village.population
+        };
+    }
+
+    const populationCount = getTotalPopulation(player);
+    const newPopulationCount = growthFunction(populationCount, player.village.hunger);
+    const populationGrowth = newPopulationCount - populationCount;
+
+    player.village.population.general += populationGrowth;
+
+    logger.log('  - ' + player.name + ': population - ' + newPopulationCount + ' | hunger: ' + player.village.hunger);
+};
+
+export const getTotalPopulation = function (player) {
+    return _.sum(_.values(_.get(player, 'village.population')));
+};

--- a/nomic-bot/src/schedule-processors/sawmill-processor.js
+++ b/nomic-bot/src/schedule-processors/sawmill-processor.js
@@ -2,87 +2,89 @@ import schedule from 'node-schedule';
 import moment from 'moment-timezone';
 import _ from 'lodash';
 import config from '../config/server-config.js';
-import logger from '../utils/logger.js';
-import github from '../utils/github.js';
-import rollProcessor from '../command-processors/roll-processor.js';
+import * as logger from '../utils/logger.js';
+import * as github from '../utils/github.js';
+import * as rollProcessor from '../command-processors/roll-processor.js';
 
-const sawmillProcessor = {
-    job: null,
-    jobSchedule: '0 0 15 * * 1',
-    sawmillProduction: '/roll 1d12+3',
-    loggersRequired: 6,
-    scheduleJob: function () {
-        if (sawmillProcessor.job) {
-            sawmillProcessor.job.cancel();
-        }
-        sawmillProcessor.job = schedule.scheduleJob(sawmillProcessor.jobSchedule, sawmillProcessor.processProduction);
-        logger.info('Creating Sawmill Production Job. Next Run: ' + sawmillProcessor.getNextRun());
-    },
-    getNextRun: function () {
-        if (sawmillProcessor.job) {
-            return moment(sawmillProcessor.job.pendingInvocations()[0].fireDate).tz(config.timezone).format('M/D/YY HH:mm z');
-        }
-        return 'NONE';
-    },
-    getActiveSawmills: function (player, sawmillCount) {
-        const sawmills = sawmillCount || _.get(player, 'village.sawmills', 0);
-        const loggers = _.get(player, 'village.population.logging', 0);
+export let job = null;
+export const jobSchedule = '0 0 15 * * 1';
+export const sawmillProduction = '/roll 1d12+3';
+export const loggersRequired = 6;
 
-        return Math.floor(Math.max(0, sawmills - Math.max(0, sawmills * sawmillProcessor.loggersRequired - loggers) / sawmillProcessor.loggersRequired));
-    },
-    processSawmillProduction: function (player, mills) {
-        const activeMills = sawmillProcessor.getActiveSawmills(player, mills);
-        const production = _.sum(_.times(activeMills, _.partial(rollProcessor.sum, sawmillProcessor.sawmillProduction, {})));
-        const currentLumber = _.get(player, 'village.lumber', 0);
-
-        logger.log('  - Processing Sawmill Production for ' + player.name + ': ' + activeMills + ' - ' + production);
-
-        if (!player || !player.village) {
-            return 0;
-        }
-
-        player.village.lumber = currentLumber + production;
-
-        return production;
-    },
-    processProduction: function () {
-        logger.info('Performing Sawmill Production Process...');
-        return github.getPlayerData()
-            .then(function (playerData){
-                if (!playerData.activePlayers) {
-                    logger.warn('No active players found!');
-                    return;
-                }
-
-                logger.log(' :: ' + playerData.activePlayers.length + ' active players :: ');
-
-                _.each(playerData.activePlayers, sawmillProcessor.processPlayerProduction);
-
-                return github.updatePlayerFile(playerData, 'Sawmill Production.')
-                    .finally(function () {
-                        logger.info('Finished Sawmill Production Process. Next Sawmill Production Job Scheduled to run at ' + sawmillProcessor.getNextRun());
-                    });
-            });
-    },
-    processPlayerProduction: function (player) {
-        if (!player.village) {
-            logger.log('  - ' + player.name + ': NO VILLAGE');
-            return;
-        }
-
-        if (!player.village.population) {
-            logger.log('  - ' + player.name + ': NO POPULATION');
-            return;
-        }
-
-        if (_.isNumber(player.village.population)) {
-            player.village.population = {
-                general: player.village.population
-            };
-        }
-
-        sawmillProcessor.processSawmillProduction(player);
+export const scheduleJob = function () {
+    if (job) {
+        job.cancel();
     }
+    job = schedule.scheduleJob(jobSchedule, processProduction);
+    logger.info('Creating Sawmill Production Job. Next Run: ' + getNextRun());
 };
 
-export default sawmillProcessor;
+export const getNextRun = function () {
+    if (job) {
+        return moment(job.pendingInvocations()[0].fireDate).tz(config.timezone).format('M/D/YY HH:mm z');
+    }
+    return 'NONE';
+};
+
+export const getActiveSawmills = function (player, sawmillCount) {
+    const sawmills = sawmillCount || _.get(player, 'village.sawmills', 0);
+    const loggers = _.get(player, 'village.population.logging', 0);
+
+    return Math.floor(Math.max(0, sawmills - Math.max(0, sawmills * loggersRequired - loggers) / loggersRequired));
+};
+
+export const processSawmillProduction = function (player, mills) {
+    const activeMills = getActiveSawmills(player, mills);
+    const production = _.sum(_.times(activeMills, _.partial(rollProcessor.sum, sawmillProduction, {})));
+    const currentLumber = _.get(player, 'village.lumber', 0);
+
+    logger.log('  - Processing Sawmill Production for ' + player.name + ': ' + activeMills + ' - ' + production);
+
+    if (!player || !player.village) {
+        return 0;
+    }
+
+    player.village.lumber = currentLumber + production;
+
+    return production;
+};
+
+export const processProduction = function () {
+    logger.info('Performing Sawmill Production Process...');
+    return github.getPlayerData()
+        .then(function (playerData){
+            if (!playerData.activePlayers) {
+                logger.warn('No active players found!');
+                return;
+            }
+
+            logger.log(' :: ' + playerData.activePlayers.length + ' active players :: ');
+
+            _.each(playerData.activePlayers, processPlayerProduction);
+
+            return github.updatePlayerFile(playerData, 'Sawmill Production.')
+                .finally(function () {
+                    logger.info('Finished Sawmill Production Process. Next Sawmill Production Job Scheduled to run at ' + getNextRun());
+                });
+        });
+};
+
+export const processPlayerProduction = function (player) {
+    if (!player.village) {
+        logger.log('  - ' + player.name + ': NO VILLAGE');
+        return;
+    }
+
+    if (!player.village.population) {
+        logger.log('  - ' + player.name + ': NO POPULATION');
+        return;
+    }
+
+    if (_.isNumber(player.village.population)) {
+        player.village.population = {
+            general: player.village.population
+        };
+    }
+
+    processSawmillProduction(player);
+};

--- a/nomic-bot/src/universe/big-bang.js
+++ b/nomic-bot/src/universe/big-bang.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
-import github from '../utils/github';
-const { getPlayerData } = github;
+import { getPlayerData } from '../utils/github';
 
 // Every one of our commands are going to have the following type signature:
 // Command -> World -> {world :: World, actions :: List Action}

--- a/nomic-bot/src/universe/interpreter.js
+++ b/nomic-bot/src/universe/interpreter.js
@@ -1,7 +1,6 @@
 import multi from 'multiple-methods';
 import _ from 'lodash';
-import github from '../utils/github'
-const { updatePlayerFile, sendCommentMessage } = github;
+import { updatePlayerFile, sendCommentMessage } from '../utils/github'
 
 // each interpreter has a type signature of:
 // Action -> World -> ()

--- a/nomic-bot/src/utils/api-server.js
+++ b/nomic-bot/src/utils/api-server.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import express from 'express';
 import bodyParser from 'body-parser';
-import logger from '../utils/logger.js';
+import * as logger from '../utils/logger.js';
 
 
 function ApiServer(options) {

--- a/nomic-bot/src/utils/github.js
+++ b/nomic-bot/src/utils/github.js
@@ -8,7 +8,7 @@ import Q from 'q';
 const githubAuth = process.env.GITHUB_AUTH;
 const testing = process.env.TESTING || false;
 const logReads = process.env.LOG_READS || false;
-import logger from '../utils/logger.js';
+import * as logger from '../utils/logger.js';
 import githubConfig from '../config/github-config.js';
 
 function processResponse(deferred, request, response) {
@@ -88,206 +88,215 @@ function logRead(options, request, response) {
     return response;
 }
 
-const github = {
-    userLogin: githubConfig.bot.userLogin,
-    get: function (options) {
-        const deferred = Q.defer();
-        const query = options.query || {};
+export const userLogin = githubConfig.bot.userLogin;
 
-        const request = https.get({
-            host: githubConfig.repository.host,
-            headers: githubConfig.repository.headers,
-            auth: githubAuth,
-            path: (options.path || '/repos/' + githubConfig.repository.owner + '/' + githubConfig.repository.repo + '/' + options.endpoint) + '?' + queryString.stringify(query)
-        }, _.partial(processResponse, deferred, request))
-        .on('error', deferred.reject);
+export const get = function (options) {
+    const deferred = Q.defer();
+    const query = options.query || {};
 
-        request.end();
-        if (logReads) {
-            return deferred.promise.then(_.partial(logRead, options, request));
-        }
-        return deferred.promise;
-    },
-    post: function (options) {
-        if (testing) {
-            return mockWrite(options, 'POST');
-        }
-        const deferred = Q.defer();
+    const request = https.get({
+        host: githubConfig.repository.host,
+        headers: githubConfig.repository.headers,
+        auth: githubAuth,
+        path: (options.path || '/repos/' + githubConfig.repository.owner + '/' + githubConfig.repository.repo + '/' + options.endpoint) + '?' + queryString.stringify(query)
+    }, _.partial(processResponse, deferred, request))
+    .on('error', deferred.reject);
 
-        const request = https.request({
-            method: 'POST',
-            host: githubConfig.repository.host,
-            headers: githubConfig.repository.headers,
-            auth: githubAuth,
-            path: options.path || '/repos/' + githubConfig.repository.owner + '/' + githubConfig.repository.repo + '/' + options.endpoint
-        }, _.partial(processResponse, deferred, request));
-
-        request.on('error', deferred.reject);
-        request.write(JSON.stringify(options.data));
-        request.end();
-
-        return deferred.promise;
-    },
-    delete: function (options) {
-        if (testing) {
-            return mockWrite(options, 'DELETE');
-        }
-        const deferred = Q.defer();
-
-        const request = https.request({
-            method: 'DELETE',
-            host: githubConfig.repository.host,
-            headers: githubConfig.repository.headers,
-            auth: githubAuth,
-            path: options.path || '/repos/' + githubConfig.repository.owner + '/' + githubConfig.repository.repo + '/' + options.endpoint
-        }, _.partial(processResponse, deferred, request));
-
-        request.on('error', deferred.reject);
-        request.write(JSON.stringify(options.data || {}));
-        request.end();
-
-        return deferred.promise;
-    },
-    put: function (options) {
-        if (testing) {
-            return mockWrite(options, 'PUT');
-        }
-        const deferred = Q.defer();
-
-        const request = https.request({
-            method: 'PUT',
-            host: githubConfig.repository.host,
-            headers: githubConfig.repository.headers,
-            auth: githubAuth,
-            path: options.path || '/repos/' + githubConfig.repository.owner + '/' + githubConfig.repository.repo + '/' + options.endpoint
-        }, _.partial(processResponse, deferred, request));
-
-        request.on('error', deferred.reject);
-        request.write(JSON.stringify(options.data));
-        request.end();
-
-        return deferred.promise;
-    },
-    patch: function (options) {
-        if (testing) {
-            return mockWrite(options, 'PATCH');
-        }
-        const deferred = Q.defer();
-
-        const request = https.request({
-            method: 'PATCH',
-            host: githubConfig.repository.host,
-            headers: githubConfig.repository.headers,
-            auth: githubAuth,
-            path: options.path || '/repos/' + githubConfig.repository.owner + '/' + githubConfig.repository.repo + '/' + options.endpoint
-        }, _.partial(processResponse, deferred, request));
-
-        request.on('error', deferred.reject);
-        request.write(JSON.stringify(options.data));
-        request.end();
-
-        return deferred.promise;
-    },
-    getFileContents: function (options) {
-        return github.get(options)
-            .then(function (fileData) {
-                if (fileData && fileData.content) {
-                    return atob(fileData.content);
-                }
-            })
-            .catch(logger.error);
-    },
-    sendCommentMessage: function (url, message) {
-        return github.post({
-            path: url,
-            data: {
-                body: message
-            }
-        })
-        .then(_.constant({message: 'Sending Message: ' + message, url: url}))
-        .catch(logger.error);
-    },
-    getAllComments: function (commentsUrl) {
-        let comments = [];
-        return github.get({
-            path: commentsUrl
-        }).then(function (commentPage) {
-            if (commentPage._meta.lastPage && commentPage._meta.lastPage !== 1) {
-                const promises = _.times(commentPage._meta.lastPage, function (n) {
-                    return github.get({
-                        path: commentsUrl,
-                        query: {
-                            page: n + 1
-                        }
-                    });
-                });
-                return Q.all(promises)
-                    .then(function (resultSet) {
-                        _.each(resultSet, function (results) {
-                            comments = comments.concat(results);
-                        });
-                        return comments;
-                    });
-            }
-            
-            return commentPage;
-        });
-    },
-    setIssueLabels: function (url, labels) {
-        url = url.replace(/{.*}/g, '');
-        return github.put({
-            path: url,
-            data: labels
-        })
-        .then(_.constant({message: 'Setting Labels', url: url, lables: labels}))
-        .catch(logger.error);
-    },
-    addIssueLabels: function (url, labels) {
-        labels = _.isArray(labels) ? labels : [labels];
-        url = url.replace(/{.*}/g, '');
-        return github.post({
-            path: url,
-            data: labels
-        })
-        .then(_.constant({message: 'Adding Labels', url: url, lables: labels}))
-        .catch(logger.error);
-    },
-    removeIssueLabel: function (url, label) {
-        url = url.replace(/{.*}/g, '');
-        return github.delete({
-            path: url + '/' + label
-        })
-        .then(_.constant({message: 'Removing Label: ' + label, url: url}))
-        .catch(logger.error);
-    },
-    updatePlayerFile: function (playerData, message) {
-        const yamlString = YAML.stringify(playerData, Number.MAX_SAFE_INTEGER);
-        
-        return github.get({
-            endpoint: 'contents/players.yaml'
-        }).then(function (playerMeta) {
-            return github.put({
-                endpoint: 'contents/players.yaml',
-                data: {
-                    message: message,
-                    committer: {
-                        name: github.userLogin,
-                        email: 'nomic-bot@archmageinc.com'
-                    },
-                    content: btoa(yamlString),
-                    sha: playerMeta.sha
-                }
-            })
-            .then(_.constant({message: 'Updating player data: ' + message, data: playerData}))
-            .catch(logger.error);
-        }).catch(logger.error);
-    },
-    getPlayerData: function () {
-        return github.getFileContents({
-                endpoint: 'contents/players.yaml'
-            })
-            .then(YAML.parse);
+    request.end();
+    if (logReads) {
+        return deferred.promise.then(_.partial(logRead, options, request));
     }
+    return deferred.promise;
 };
 
-export default github;
+export const post = function (options) {
+    if (testing) {
+        return mockWrite(options, 'POST');
+    }
+    const deferred = Q.defer();
+
+    const request = https.request({
+        method: 'POST',
+        host: githubConfig.repository.host,
+        headers: githubConfig.repository.headers,
+        auth: githubAuth,
+        path: options.path || '/repos/' + githubConfig.repository.owner + '/' + githubConfig.repository.repo + '/' + options.endpoint
+    }, _.partial(processResponse, deferred, request));
+
+    request.on('error', deferred.reject);
+    request.write(JSON.stringify(options.data));
+    request.end();
+
+    return deferred.promise;
+};
+
+export const remove = function (options) {
+    if (testing) {
+        return mockWrite(options, 'DELETE');
+    }
+    const deferred = Q.defer();
+
+    const request = https.request({
+        method: 'DELETE',
+        host: githubConfig.repository.host,
+        headers: githubConfig.repository.headers,
+        auth: githubAuth,
+        path: options.path || '/repos/' + githubConfig.repository.owner + '/' + githubConfig.repository.repo + '/' + options.endpoint
+    }, _.partial(processResponse, deferred, request));
+
+    request.on('error', deferred.reject);
+    request.write(JSON.stringify(options.data || {}));
+    request.end();
+
+    return deferred.promise;
+};
+
+export const put = function (options) {
+    if (testing) {
+        return mockWrite(options, 'PUT');
+    }
+    const deferred = Q.defer();
+
+    const request = https.request({
+        method: 'PUT',
+        host: githubConfig.repository.host,
+        headers: githubConfig.repository.headers,
+        auth: githubAuth,
+        path: options.path || '/repos/' + githubConfig.repository.owner + '/' + githubConfig.repository.repo + '/' + options.endpoint
+    }, _.partial(processResponse, deferred, request));
+
+    request.on('error', deferred.reject);
+    request.write(JSON.stringify(options.data));
+    request.end();
+
+    return deferred.promise;
+};
+
+export const patch = function (options) {
+    if (testing) {
+        return mockWrite(options, 'PATCH');
+    }
+    const deferred = Q.defer();
+
+    const request = https.request({
+        method: 'PATCH',
+        host: githubConfig.repository.host,
+        headers: githubConfig.repository.headers,
+        auth: githubAuth,
+        path: options.path || '/repos/' + githubConfig.repository.owner + '/' + githubConfig.repository.repo + '/' + options.endpoint
+    }, _.partial(processResponse, deferred, request));
+
+    request.on('error', deferred.reject);
+    request.write(JSON.stringify(options.data));
+    request.end();
+
+    return deferred.promise;
+};
+
+export const getFileContents = function (options) {
+    return get(options)
+        .then(function (fileData) {
+            if (fileData && fileData.content) {
+                return atob(fileData.content);
+            }
+        })
+        .catch(logger.error);
+};
+
+export const sendCommentMessage = function (url, message) {
+    return post({
+        path: url,
+        data: {
+            body: message
+        }
+    })
+    .then(_.constant({message: 'Sending Message: ' + message, url: url}))
+    .catch(logger.error);
+};
+
+export const getAllComments = function (commentsUrl) {
+    let comments = [];
+    return get({
+        path: commentsUrl
+    }).then(function (commentPage) {
+        if (commentPage._meta.lastPage && commentPage._meta.lastPage !== 1) {
+            const promises = _.times(commentPage._meta.lastPage, function (n) {
+                return get({
+                    path: commentsUrl,
+                    query: {
+                        page: n + 1
+                    }
+                });
+            });
+            return Q.all(promises)
+                .then(function (resultSet) {
+                    _.each(resultSet, function (results) {
+                        comments = comments.concat(results);
+                    });
+                    return comments;
+                });
+        }
+        
+        return commentPage;
+    });
+};
+
+export const setIssueLabels = function (url, labels) {
+    url = url.replace(/{.*}/g, '');
+    return put({
+        path: url,
+        data: labels
+    })
+    .then(_.constant({message: 'Setting Labels', url: url, lables: labels}))
+    .catch(logger.error);
+};
+
+export const addIssueLabels = function (url, labels) {
+    labels = _.isArray(labels) ? labels : [labels];
+    url = url.replace(/{.*}/g, '');
+    return post({
+        path: url,
+        data: labels
+    })
+    .then(_.constant({message: 'Adding Labels', url: url, lables: labels}))
+    .catch(logger.error);
+};
+
+export const removeIssueLabel = function (url, label) {
+    url = url.replace(/{.*}/g, '');
+    return remove({
+        path: url + '/' + label
+    })
+    .then(_.constant({message: 'Removing Label: ' + label, url: url}))
+    .catch(logger.error);
+};
+
+export const updatePlayerFile = function (playerData, message) {
+    const yamlString = YAML.stringify(playerData, Number.MAX_SAFE_INTEGER);
+    
+    return get({
+        endpoint: 'contents/players.yaml'
+    }).then(function (playerMeta) {
+        return put({
+            endpoint: 'contents/players.yaml',
+            data: {
+                message: message,
+                committer: {
+                    name: userLogin,
+                    email: 'nomic-bot@archmageinc.com'
+                },
+                content: btoa(yamlString),
+                sha: playerMeta.sha
+            }
+        })
+        .then(_.constant({message: 'Updating player data: ' + message, data: playerData}))
+        .catch(logger.error);
+    }).catch(logger.error);
+};
+
+export const getPlayerData = function () {
+    return getFileContents({
+            endpoint: 'contents/players.yaml'
+        })
+        .then(YAML.parse);
+};

--- a/nomic-bot/src/utils/logger.js
+++ b/nomic-bot/src/utils/logger.js
@@ -1,23 +1,23 @@
 import moment from 'moment-timezone';
 import config from '../config/server-config.js';
 
-const logger = {
-    getPrefix: function () {
-        return moment().tz(config.timezone).format('[[]M/D/YY HH:mm z[]]: ');
-    },
-    info: function (message) {
-        console.info(logger.getPrefix() + message);
-    },
-    log: function (message) {
-        console.log(message);
-    },
-    warn: function (message) {
-        console.warn(logger.getPrefix() + message);
-    },
-    error: function (message) {
-        console.error(logger.getPrefix(), message);
-        throw new Error(message);
-    }
+export const getPrefix = function () {
+    return moment().tz(config.timezone).format('[[]M/D/YY HH:mm z[]]: ');
 };
 
-export default logger;
+export const info = function (message) {
+    console.info(getPrefix() + message);
+};
+
+export const log = function (message) {
+    console.log(message);
+};
+
+export const warn = function (message) {
+    console.warn(getPrefix() + message);
+};
+
+export const error = function (message) {
+    console.error(getPrefix(), message);
+    throw new Error(message);
+};


### PR DESCRIPTION
This one is a bit more iffy. Most of this was mechanical with a codemod I wrote (my first big one!). But I did do some manual things. Overall, I think it will work, but I really do need to have a test suite setup to be sure. But adding tests adds to the overhead of people contributing.

I do think that overall this change is positive even if in inadvertently breaks something. Breaking out these objects in the parts allows for greater flexibility with refactoring.

The next codemod I want to write will get rid of the "import \* as" and change it to destructuring. This shouldn't be too hard and will definitely help clean things up.

After that I want to add a linter, experiment with different ways of adding commands, and work more on the framework and documentation for authoring commands.
