### PR TITLE
Fixed quorum to calculate properly

### DIFF
--- a/nomic-bot/src/command-processors/vote-processor.js
+++ b/nomic-bot/src/command-processors/vote-processor.js
@@ -126,7 +126,7 @@ export const processVote = function (commentsUrl, userLogin, requestBody) {
             });
             logger.log('  === Finished Counting ===');
 
-            hasQuorum = _.size(votes) > quorum;
+            hasQuorum = _.size(votes) >= quorum;
 
             if (hasQuorum) {
                 


### PR DESCRIPTION
The scenario we were just is was 5 active players, 3 votes.  Math.ceil(5 \* 0.5) = 3, but quorum wouldn't be considered reached until 4. This is not correct.
