### PR TITLE
Fixed the /happy command.

### DIFF
--- a/nomic-bot/src/universe/commands/happy.js
+++ b/nomic-bot/src/universe/commands/happy.js
@@ -11,7 +11,8 @@ addCommand('/happy', (_, { playerComments, player }) => {
         .min()
         .value()
 
-    if (latestHappyCommentWeeks === undefined || latestHappyCommentWeeks >= 1) {
+    // Greater than one, because we shouldn't count the comment that started the command.
+    if (latestHappyCommentWeeks > 1) {
         player.village.happiness += 1;
         return [
             updatePlayer(player),


### PR DESCRIPTION
When I was testing this I didn't actually leave a comment in the audit log, I just posted the event. This meant when I pulled the comments, there were no comments with /happy. But of course in actuallity, you would post a comment. That means if the /happy command has been run that there is at least one /happy comment you have left in the last week, the one you just left. So instead I need to check that this is your only /happy comment in the last week. This fixes that problem.
