### PR TITLE
 Fixes errors when nomic-bot left comments.

### DIFF
--- a/nomic-bot/src/endpoint-processors/comment-processor.js
+++ b/nomic-bot/src/endpoint-processors/comment-processor.js
@@ -49,7 +49,7 @@ export const processComment = function (request, responder) {
     const body = request.body;
     const issue = body.issue;
     const comment = body.comment;
-    if (body.action === 'created') {
+    if (body.action === 'created' && comment.user.login !== 'nomic-bot') {
         return processCommand(splitCommand(comment.body), { issue, comment, body })
             .then(trapUncaughtCommands(body))
             .then(_.partial(sendResponse, responder))


### PR DESCRIPTION
We shouldn't try to run any command logic if the comment is left by nomic bot. This fixes #116.
